### PR TITLE
Add detection for FreeBSD x86-64.

### DIFF
--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -23,7 +23,12 @@ if uname | grep -iq 'Linux'; then
   else
     fail "On Linux, the only arch currently supported is: x86_64"
   fi
-  # TODO: Add FreeBSD when binary builds for it are supported.
+elif uname | grep -iq 'FreeBSD'; then
+  if uname -m | grep -iq 'amd64'; then
+    echo 'x86_64-unknown-freebsd'
+  else
+    fail "On FreeBSD, the only arch currently supported is: x86_64"
+  fi
 elif uname | grep -iq 'Darwin'; then
   if uname -m | grep -iq 'x86_64'; then
     echo 'x86_64-apple-macosx'


### PR DESCRIPTION
This PR in theory makes it possible to use `asdf` to install Savi on a FreeBSD x86-64 machine, once the first such release is made available.

I say "in theory" because this PR does not add CI, as [FreeBSD CI is not yet supported in GitHub Actions](https://github.com/actions/runner/issues/385), and I don't want to rewrite all the CI stuff in CirrusCI just for the marginal benefit of CI-testing these handful of lines in the platform detection code.